### PR TITLE
list column type unit tests

### DIFF
--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -1908,15 +1908,16 @@ class CsvFileTable(TableAbstractBaseClass):
 
             # determine which columns are DATE columns so we can convert milisecond timestamps into datetime objects
             date_columns = []
-            if convert_to_datetime:
-                for select_column in self.headers:
-                    if select_column.columnType == "DATE":
-                        date_columns.append(select_column.name)
             list_columns = []
-            for select_column in self.headers:
-                if select_column.columnType in {'STRING_LIST', 'INTEGER_LIST', 'BOOLEAN_LIST'}:
-                    list_columns.append(select_column.name)
 
+            if self.headers is not None:
+                if convert_to_datetime:
+                    for select_column in self.headers:
+                        if select_column.columnType == "DATE":
+                            date_columns.append(select_column.name)
+                for select_column in self.headers:
+                    if select_column.columnType in {'STRING_LIST', 'INTEGER_LIST', 'BOOLEAN_LIST'}:
+                        list_columns.append(select_column.name)
             return _csv_to_pandas_df(self.filepath,
                                      separator=self.separator,
                                      quote_char=quoteChar,

--- a/synapseclient/table.py
+++ b/synapseclient/table.py
@@ -551,6 +551,11 @@ def _csv_to_pandas_df(filepath,
 
     line_terminator = str(os.linesep)
 
+    # assign line terminator only if for single character
+    # line terminators (e.g. not '\r\n') 'cause pandas doesn't
+    # longer line terminators. See:
+    #    https://github.com/pydata/pandas/issues/3501
+    # "ValueError: Only length-1 line terminators supported"
     df = pd.read_csv(filepath,
                      sep=separator,
                      lineterminator=line_terminator if len(line_terminator) == 1 else None,
@@ -1911,11 +1916,7 @@ class CsvFileTable(TableAbstractBaseClass):
             for select_column in self.headers:
                 if select_column.columnType in {'STRING_LIST', 'INTEGER_LIST', 'BOOLEAN_LIST'}:
                     list_columns.append(select_column.name)
-            # assign line terminator only if for single character
-            # line terminators (e.g. not '\r\n') 'cause pandas doesn't
-            # longer line terminators. See:
-            #    https://github.com/pydata/pandas/issues/3501
-            # "ValueError: Only length-1 line terminators supported"
+
             return _csv_to_pandas_df(self.filepath,
                                      separator=self.separator,
                                      quote_char=quoteChar,

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -1122,6 +1122,29 @@ class TestCsvFileTable:
             for expected_row, table_row in zip(expected_rows, table):
                 assert expected_row == table_row
 
+    def test_as_data_frame__no_headers(self):
+        """Verify we don't assume a schema has defined headers when converting to a Pandas data frame"""
+        data = {
+            'ROW_ID': ['1', '5'],
+            'ROW_VERSION': ['2', '1'],
+            'ROW_ETAG': ['etag1', 'etag2'],
+            'col': ['I like trains', 'weeeeeeeeeeee']
+        }
+        pd_df = pd.DataFrame(data)
+
+        expected_df = pd.DataFrame(
+            index=['1_2_etag1', '5_1_etag2'],
+            columns=['col'],
+            data=data['col'],
+        )
+
+        with patch.object(pd, 'read_csv') as mock_read_csv:
+            mock_read_csv.return_value = pd_df
+            table = CsvFileTable('syn123', '/fake/file/path')
+            df = table.asDataFrame()
+
+        pd.testing.assert_frame_equal(expected_df, df)
+
 
 def test_Row_forward_compatibility():
     row = Row("2, 3, 4", rowId=1, versionNumber=1, etag=None, new_field="new")

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -1145,6 +1145,38 @@ class TestCsvFileTable:
 
         pd.testing.assert_frame_equal(expected_df, df)
 
+    def test_as_data_frame__list_columns(self):
+        """Verify list columns are represented as expected when converted to a Pandas dataframe"""
+
+        data = {
+            'string_list': ['["foo", "bar"]', '["wizzle", "wozzle"]'],
+            'integer_list': ['[1, 5]', '[2, 1]'],
+            'boolean_list': ['[true, false]', '[false, true]'],
+            'fill': [None, None],
+        }
+        pd_df = pd.DataFrame(data)
+
+        expected_df = pd.DataFrame({
+           'string_list': [['foo', 'bar'], ['wizzle', 'wozzle']],
+           'integer_list': [[1, 5], [2, 1]],
+           'boolean_list': [[True, False], [False, True]],
+           'fill': [[], []],
+        })
+
+        headers = [
+            SelectColumn(name='string_list', columnType='STRING_LIST'),
+            SelectColumn(name='integer_list', columnType='INTEGER_LIST'),
+            SelectColumn(name='boolean_list', columnType='BOOLEAN_LIST'),
+            SelectColumn(name='fill', columnType='STRING_LIST'),
+        ]
+
+        with patch.object(pd, 'read_csv') as mock_read_csv:
+            mock_read_csv.return_value = pd_df
+            table = CsvFileTable('syn123', '/fake/file/path', headers=headers)
+            df = table.asDataFrame()
+
+        pd.testing.assert_frame_equal(expected_df, df)
+
 
 def test_Row_forward_compatibility():
     row = Row("2, 3, 4", rowId=1, versionNumber=1, etag=None, new_field="new")

--- a/tests/unit/synapseclient/unit_test_tables.py
+++ b/tests/unit/synapseclient/unit_test_tables.py
@@ -1157,10 +1157,10 @@ class TestCsvFileTable:
         pd_df = pd.DataFrame(data)
 
         expected_df = pd.DataFrame({
-           'string_list': [['foo', 'bar'], ['wizzle', 'wozzle']],
-           'integer_list': [[1, 5], [2, 1]],
-           'boolean_list': [[True, False], [False, True]],
-           'fill': [[], []],
+            'string_list': [['foo', 'bar'], ['wizzle', 'wozzle']],
+            'integer_list': [[1, 5], [2, 1]],
+            'boolean_list': [[True, False], [False, True]],
+            'fill': [[], []],
         })
 
         headers = [


### PR DESCRIPTION
Adds a unit tests for your list column type conversion PR as well as a test to cover a previously untested case where there were no defined headers which would cause an error when looking for list column types.