### PR TITLE
Enable manifest piping into `synapse sync`

### DIFF
--- a/synapseclient/__main__.py
+++ b/synapseclient/__main__.py
@@ -613,12 +613,12 @@ def build_parser():
         'path', metavar='PATH', type=str,
         help='A path to a file or folder whose manifest will be generated.')
     parser_manifest.add_argument(
-        '--parentid', '--parentId', metavar='syn123', type=str,
+        '--parent-id', metavar='syn123', type=str,
         required=True, dest='parentid',
         help='Synapse ID of project or folder where to upload data.')
     parser_manifest.add_argument(
-        '--manifest-file', metavar='OUTPUT', default="SYNAPSE_METADATA_MANIFEST.tsv",
-        help='A TSV output file path where the generated manifest is stored. (default: %(default)s)')
+        '--manifest-file', metavar='OUTPUT',
+        help='A TSV output file path where the generated manifest is stored. (default: stdout)')
     parser_manifest.set_defaults(func=manifest)
 
     parser_sync = subparsers.add_parser('sync',
@@ -629,7 +629,7 @@ def build_parser():
                              help='Send notifications via Synapse messaging (email) at specific intervals, '
                                   'on errors and on completion.')
     parser_sync.add_argument('--retries', metavar='INT', type=int, default=4)
-    parser_sync.add_argument('manifestFile', metavar='FILE', type=str,
+    parser_sync.add_argument('manifestFile', metavar='FILE', type=argparse.FileType("r"),
                              help='A tsv file with file locations and metadata to be pushed to Synapse.')
     parser_sync.set_defaults(func=sync)
 

--- a/synapseutils/sync.py
+++ b/synapseutils/sync.py
@@ -676,7 +676,7 @@ def _get_file_entity_provenance_dict(syn, entity):
 
 
 def _write_manifest_data(filename, keys, data):
-    with io.open(filename, 'w', encoding='utf8') as fp:
+    with io.open(filename, 'w', encoding='utf8') if filename else sys.stdout as fp:
         csv_writer = csv.DictWriter(fp, keys, restval='', extrasaction='ignore', delimiter='\t')
         csv_writer.writeheader()
         for row in data:
@@ -761,7 +761,10 @@ def readManifestFile(syn, manifestFile):
     table.test_import_pandas()
     import pandas as pd
 
-    sys.stdout.write('Validation and upload of: %s\n' % manifestFile)
+    if manifestFile is sys.stdin:
+        sys.stdout.write('Validation and upload of: <stdin>\n')
+    else:
+        sys.stdout.write('Validation and upload of: %s\n' % manifestFile)
     # Read manifest file into pandas dataframe
     df = pd.read_csv(manifestFile, sep='\t')
     if 'synapseStore' not in df:
@@ -977,14 +980,11 @@ def _check_size_each_file(df):
                 raise ValueError("File {} is empty, empty files cannot be uploaded to Synapse".format(file_name))
 
 
-def generate_sync_manifest(syn, directory_path, parent_id,
-                           manifest_path="SYNAPSE_METADATA_MANIFEST.tsv"):
+def generate_sync_manifest(syn, directory_path, parent_id, manifest_path):
     """Generate manifest for syncToSynapse() from a local directory."""
     manifest_cols = ["path", "parent"]
     manifest_rows = _walk_directory_tree(syn, directory_path, parent_id)
     _write_manifest_data(manifest_path, manifest_cols, manifest_rows)
-    print(manifest_path)
-    return(manifest_path)
 
 
 def _create_folder(syn, name, parent_id):


### PR DESCRIPTION
Example command and output:

```
❯ synapse manifest --parent-id syn26341061 ./docs/ | synapse sync -
Validation and upload of: <stdin>
Validating columns of manifest.....OK
Validating that all paths exist.....................................................................OK
Validating that all files are unique...OK
Validating that all the files are not empty...OK
Validating provenance...OK
Validating that parents exist and are containers...OK
==================================================
We are about to upload 80 files with a total size of 1.8MB.
 ==================================================
Starting upload...
```